### PR TITLE
Respect inherited groupId and version.

### DIFF
--- a/plugin/maven3/src/main/java/com/buschmais/jqassistant/plugin/maven3/impl/scanner/AbstractMavenPomScannerPlugin.java
+++ b/plugin/maven3/src/main/java/com/buschmais/jqassistant/plugin/maven3/impl/scanner/AbstractMavenPomScannerPlugin.java
@@ -463,10 +463,10 @@ public abstract class AbstractMavenPomScannerPlugin extends AbstractScannerPlugi
     protected MavenPomXmlDescriptor createMavenPomXmlDescriptor(Model model, FileResource item, String path, Scanner scanner) {
         MavenPomXmlDescriptor pomXmlDescriptor = scanner.getContext().getStore().create(MavenPomXmlDescriptor.class);
         pomXmlDescriptor.setName(model.getName());
-        pomXmlDescriptor.setGroupId(model.getGroupId());
+        pomXmlDescriptor.setGroupId(model.getGroupId() != null ? model.getGroupId() : model.getParent() != null ? model.getParent().getGroupId() : null);
         pomXmlDescriptor.setArtifactId(model.getArtifactId());
         pomXmlDescriptor.setPackaging(model.getPackaging());
-        pomXmlDescriptor.setVersion(model.getVersion());
+        pomXmlDescriptor.setVersion(model.getVersion() != null ? model.getVersion() : model.getParent() != null ? model.getParent().getVersion() : null);
         pomXmlDescriptor.setFullQualifiedName(model.getId());
         MavenArtifactDescriptor artifact = ArtifactResolver.resolve(new ModelCoordinates(model), MavenArtifactDescriptor.class, scanner.getContext());
         pomXmlDescriptor.setDescribes(artifact);


### PR DESCRIPTION
When creating the MavenPomXmlDescriptor out of the org.apache.maven.model.Model then it should be respected that groupId and version can come from the parent (see code).