### PR TITLE
Updated the Maven Dependency Plugin to version 2.8

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -161,7 +161,7 @@
                                             <pluginExecutionFilter>
                                                 <groupId>org.apache.maven.plugins</groupId>
                                                 <artifactId>maven-dependency-plugin</artifactId>
-                                                <versionRange>[2.7.0,)</versionRange>
+                                                <versionRange>[2.8.0,)</versionRange>
                                                 <goals>
                                                     <goal>copy-dependencies</goal>
                                                 </goals>
@@ -331,7 +331,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-dependency-plugin</artifactId>
-                    <version>2.7</version>
+                    <version>2.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Updated the Maven Dependency Plugin to version 2.8. With 2.7 I have been unable to run mvn dependency:tree successfully.