### PR TITLE
New property for files containing YAML documents

### DIFF
--- a/plugin/yaml/src/main/asciidoc/scanner.adoc
+++ b/plugin/yaml/src/main/asciidoc/scanner.adoc
@@ -33,6 +33,8 @@ A file with the file extension `.yaml` containing zero or more YAML documents.
 | parsed | Property to indicate if the documents of this file have been parsed
            successfully or not. If the YAML scanner was able to parse all
            documents, this property is _true_. Otherwise it is _false_.
+           This property can be used to check if all of your YAML files
+           could have been parsed or not.
 |====
 
 [[:Document:YAML]]

--- a/plugin/yaml/src/main/asciidoc/scanner.adoc
+++ b/plugin/yaml/src/main/asciidoc/scanner.adoc
@@ -26,6 +26,15 @@ A file with the file extension `.yaml` containing zero or more YAML documents.
 | HAS_ROOT_ELEMENT | <<:Document:YAML>> | 0..n           | References a document in the file
 |====
 
+.Properties of :File:YAML
+[options="header"]
+|====
+| Name   | Description
+| parsed | Property to indicate if the documents of this file have been parsed
+           successfully or not. If the YAML scanner was able to parse all
+           documents, this property is _true_. Otherwise it is _false_.
+|====
+
 [[:Document:YAML]]
 === :Document:YAML
 

--- a/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/api/model/YAMLFileDescriptor.java
+++ b/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/api/model/YAMLFileDescriptor.java
@@ -1,6 +1,7 @@
 package com.buschmais.jqassistant.plugin.yaml.api.model;
 
 import com.buschmais.jqassistant.plugin.common.api.model.FileDescriptor;
+import com.buschmais.xo.neo4j.api.annotation.Property;
 import com.buschmais.xo.neo4j.api.annotation.Relation;
 
 import java.util.List;
@@ -9,4 +10,9 @@ public interface YAMLFileDescriptor extends YAMLDescriptor, FileDescriptor {
 
     @Relation("CONTAINS_DOCUMENT")
     List<YAMLDocumentDescriptor> getDocuments();
+
+    void setParsed(boolean parsable);
+
+    @Property("parsed")
+    boolean getParsed();
 }

--- a/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLEmitter.java
+++ b/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLEmitter.java
@@ -231,8 +231,21 @@ class YAMLEmitter implements Emitable {
 
             YAMLValueBucket bucket = processingContext.peek();
             bucket.getValues().add(value);
+        } else if (processingContext.isContext(DOCUMENT_CTX)) {
+            YAMLValueDescriptor value = currentScanner.getContext()
+                                                      .getStore()
+                                                      .create(YAMLValueDescriptor.class);
+
+            String rawValue = event.getValue();
+
+            value.setValue(trimToEmpty(rawValue));
+
+            YAMLValueBucket bucket = processingContext.peek();
+            bucket.getValues().add(value);
+        } else {
+            unsupportedYAMLStructure(event);
         }
-    }
+}
 
     private EventType toEventType(Event event) {
         EventType result = null;

--- a/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPlugin.java
+++ b/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPlugin.java
@@ -52,6 +52,7 @@ public class YAMLFileScannerPlugin extends AbstractScannerPlugin<FileResource, Y
         YAMLFileDescriptor yamlFileDescriptor = store.addDescriptorType(fileDescriptor, YAMLFileDescriptor.class);
 
         yamlFileDescriptor.setFileName(item.getFile().getAbsolutePath());
+        yamlFileDescriptor.setParsed(false);
 
         try (InputStream in = item.createStream()) {
             Iterable<Object> docs = yaml.loadAll(in);
@@ -65,6 +66,12 @@ public class YAMLFileScannerPlugin extends AbstractScannerPlugin<FileResource, Y
                 serializer.serialize(node);
                 serializer.close();
             }
+
+            // In case the content of the file is not parseable set parsed=false
+            // to help the user to identify nonparseable files
+            yamlFileDescriptor.setParsed(true);
+        } catch (RuntimeException rt) {
+            // @todo Logging is desired here Oliver B. Fischer, 23.08.2015
         }
 
         return yamlFileDescriptor;

--- a/plugin/yaml/src/test/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPluginIT.java
+++ b/plugin/yaml/src/test/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPluginIT.java
@@ -10,6 +10,7 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasSize;
+import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.nullValue;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 
@@ -631,6 +632,54 @@ public class YAMLFileScannerPluginIT extends AbstractPluginIT {
     public void scanLogFileYAML() {
 //             {"/probes/yamlspec/1.1/sec-2.5-example-2.28-log-file.yaml"},
         Assert.fail("Not implemented yet!");
+    }
+
+    @Test
+    public void scanAnInvalidMappingAndParsedIsFalse() {
+        store.beginTransaction();
+
+        String fileName = "invalid-mapping.yaml";
+
+        File yamlFile = new File(getClassesDirectory(YAMLFileScannerPluginValidFileSetIT.class),
+                                 "/probes/invalid/" + fileName);
+
+        getScanner().scan(yamlFile, yamlFile.getAbsolutePath(), null);
+
+        List<YAMLFileDescriptor> fileDescriptors =
+             query(format("MATCH (f:YAML:File) WHERE f.fileName=~'.*/%s' RETURN f", fileName))
+                  .getColumn("f");
+
+        assertThat(fileDescriptors, hasSize(1));
+
+        YAMLFileDescriptor fileDescriptor = fileDescriptors.get(0);
+
+        assertThat(fileDescriptor.getParsed(), is(false));
+
+        store.commitTransaction();
+    }
+
+    @Test
+    public void scanAnValidMappingAndParsedIsTrue() {
+        store.beginTransaction();
+
+        String fileName = "simple-list.yaml";
+
+        File yamlFile = new File(getClassesDirectory(YAMLFileScannerPluginValidFileSetIT.class),
+                                 "/probes/valid/" + fileName);
+
+        getScanner().scan(yamlFile, yamlFile.getAbsolutePath(), null);
+
+        List<YAMLFileDescriptor> fileDescriptors =
+             query(format("MATCH (f:YAML:File) WHERE f.fileName=~'.*/%s' RETURN f", fileName))
+                  .getColumn("f");
+
+        assertThat(fileDescriptors, hasSize(1));
+
+        YAMLFileDescriptor fileDescriptor = fileDescriptors.get(0);
+
+        assertThat(fileDescriptor.getParsed(), is(true));
+
+        store.commitTransaction();
     }
 
     /**

--- a/plugin/yaml/src/test/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/util/StringValueMatcherTest.java
+++ b/plugin/yaml/src/test/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/util/StringValueMatcherTest.java
@@ -1,0 +1,77 @@
+package com.buschmais.jqassistant.plugin.yaml.impl.scanner.util;
+
+import com.buschmais.jqassistant.plugin.yaml.api.model.YAMLValueDescriptor;
+import org.hamcrest.CoreMatchers;
+import org.hamcrest.Matcher;
+import org.hamcrest.Matchers;
+import org.junit.Test;
+import org.mockito.Mockito;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.hamcrest.CoreMatchers.is;
+import static org.hamcrest.CoreMatchers.not;
+import static org.junit.Assert.*;
+
+public class StringValueMatcherTest {
+
+    @Test
+    public void matcherReturnTrueIfYAMLValueDescriptorHasRequiredStringValue() {
+        YAMLValueDescriptor mockedYVD = Mockito.mock(YAMLValueDescriptor.class);
+
+        Mockito.when(mockedYVD.getValue()).thenReturn("ABC");
+
+        StringValueMatcher matcher = new StringValueMatcher("ABC");
+
+        assertThat(matcher.matchesSafely(mockedYVD), is(true));
+    }
+
+    @Test
+    public void matcherReturnTrueIfYAMLValueDescriptorHasNotRequiredStringValue() {
+        YAMLValueDescriptor mockedYVD = Mockito.mock(YAMLValueDescriptor.class);
+
+        Mockito.when(mockedYVD.getValue()).thenReturn("CBA");
+
+        StringValueMatcher matcher = new StringValueMatcher("ABC");
+
+        assertThat(matcher.matchesSafely(mockedYVD), is(false));
+    }
+
+    @Test
+    public void matcherCanBeUsedInConjunctionWithCollectionAndHasItem() {
+        YAMLValueDescriptor valueA = Mockito.mock(YAMLValueDescriptor.class);
+        YAMLValueDescriptor valueB = Mockito.mock(YAMLValueDescriptor.class);
+
+        Mockito.when(valueA.getValue()).thenReturn("A");
+        Mockito.when(valueB.getValue()).thenReturn("B");
+
+        List<YAMLValueDescriptor> list = new ArrayList<>(2);
+
+        list.add(valueA);
+        list.add(valueB);
+
+        Matcher<Iterable<? super YAMLValueDescriptor>> matcher = Matchers.hasItem(StringValueMatcher.hasValue("A"));
+
+        assertThat(list, matcher);
+    }
+
+    @Test
+    public void matcherFailsIfAGivenCollectionDoesNotContainASingleMatch() {
+        YAMLValueDescriptor valueA = Mockito.mock(YAMLValueDescriptor.class);
+        YAMLValueDescriptor valueB = Mockito.mock(YAMLValueDescriptor.class);
+
+        Mockito.when(valueA.getValue()).thenReturn("A");
+        Mockito.when(valueB.getValue()).thenReturn("B");
+
+        List<YAMLValueDescriptor> list = new ArrayList<>(2);
+
+        list.add(valueA);
+        list.add(valueB);
+
+        Matcher<Iterable<? super YAMLValueDescriptor>> matcher = Matchers.hasItem(StringValueMatcher.hasValue("C"));
+
+        assertThat(list, not(matcher));
+    }
+}

--- a/plugin/yaml/src/test/resources/probes/invalid/invalid-mapping.yaml
+++ b/plugin/yaml/src/test/resources/probes/invalid/invalid-mapping.yaml
@@ -1,0 +1,1 @@
+foo: somebody said I should put a colon here: so I did


### PR DESCRIPTION
I added a property to the YAMLFileDescriptor. This property can be used to check if there are files with YAML documents which could be parsed by the YAML plugin. This property is usefull to find files which cannot be analysed for various reasons by jQAassistant.