### PR TITLE
Better handling for non-parsable files with YAML documents

### DIFF
--- a/plugin/yaml/src/main/asciidoc/scanner.adoc
+++ b/plugin/yaml/src/main/asciidoc/scanner.adoc
@@ -22,8 +22,8 @@ A file with the file extension `.yaml` containing zero or more YAML documents.
 .Relations of :File:Xml
 [options="header"]
 |====
-| Name             | Target label(s)    | Cardinality    | Description
-| HAS_ROOT_ELEMENT | <<:Document:YAML>> | 0..n           | References a document in the file
+| Name              | Target label(s)    | Cardinality    | Description
+| CONTAINS_DOCUMENT | <<:Document:YAML>> | 0..n           | References a document in the file
 |====
 
 .Properties of :File:YAML

--- a/plugin/yaml/src/main/asciidoc/scanner.adoc
+++ b/plugin/yaml/src/main/asciidoc/scanner.adoc
@@ -37,6 +37,10 @@ A file with the file extension `.yaml` containing zero or more YAML documents.
            could have been parsed or not.
 |====
 
+An non-parsable file with YAML documents will not have any outgoing relationships
+to any dependent <<:Document:YAML,YAML documents>>. Please consider this aspect
+when writing your queries.
+
 [[:Document:YAML]]
 === :Document:YAML
 

--- a/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPlugin.java
+++ b/plugin/yaml/src/main/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPlugin.java
@@ -5,6 +5,7 @@ import java.io.InputStream;
 import java.util.Arrays;
 import java.util.List;
 
+import com.buschmais.jqassistant.plugin.yaml.api.model.YAMLDocumentDescriptor;
 import org.yaml.snakeyaml.DumperOptions;
 import org.yaml.snakeyaml.Yaml;
 import org.yaml.snakeyaml.constructor.Constructor;
@@ -71,6 +72,9 @@ public class YAMLFileScannerPlugin extends AbstractScannerPlugin<FileResource, Y
             // to help the user to identify nonparseable files
             yamlFileDescriptor.setParsed(true);
         } catch (RuntimeException rt) {
+            for (YAMLDocumentDescriptor documentDescriptor : yamlFileDescriptor.getDocuments()) {
+                yamlFileDescriptor.getDocuments().remove(documentDescriptor);
+            }
             // @todo Logging is desired here Oliver B. Fischer, 23.08.2015
         }
 

--- a/plugin/yaml/src/test/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPluginValidFileSetIT.java
+++ b/plugin/yaml/src/test/java/com/buschmais/jqassistant/plugin/yaml/impl/scanner/YAMLFileScannerPluginValidFileSetIT.java
@@ -22,6 +22,7 @@ public class YAMLFileScannerPluginValidFileSetIT extends AbstractPluginIT {
     @Parameterized.Parameters
     public static Collection<Object[]> data() {
         return Arrays.asList(new Object[][] {
+             {"/probes/valid/hostconfig.yaml"},
              {"/probes/valid/simple-key-value-pair.yaml"},
              {"/probes/valid/two-simple-key-value-pairs.yaml"},
              {"/probes/valid/simple-list.yaml"},

--- a/plugin/yaml/src/test/resources/probes/invalid/hostconfig-2-invalid.yaml
+++ b/plugin/yaml/src/test/resources/probes/invalid/hostconfig-2-invalid.yaml
@@ -1,0 +1,21 @@
+---
+server:
+  - name: Aurelia
+---
+service::email_server_host: 'mail.server.org'
+service::email_server_port: 25
+
+# %{::uuu} is not a valid token
+# see hostconfig.yml
+service::master_pattern: %{::uuu}
+service::cluster_id: 1
+
+service::listpusher_yps_enabled: true
+service::listpusher_yps_enabled: true
+xyz_hosts_int:
+  - 'hosta.somewhere.in.no'
+  - 'hostb.somewhere.in.no'
+
+service::b_enabled: true
+service::a_enabled: false
+

--- a/plugin/yaml/src/test/resources/probes/invalid/hostconfig-invalid.yaml
+++ b/plugin/yaml/src/test/resources/probes/invalid/hostconfig-invalid.yaml
@@ -1,0 +1,17 @@
+service::email_server_host: 'mail.server.org'
+service::email_server_port: 25
+
+# %{::uuu} is not a valid token
+# see hostconfig.yml
+service::master_pattern: %{::uuu}
+service::cluster_id: 1
+
+service::listpusher_yps_enabled: true
+service::listpusher_yps_enabled: true
+xyz_hosts_int:
+  - 'hosta.somewhere.in.no'
+  - 'hostb.somewhere.in.no'
+
+service::b_enabled: true
+service::a_enabled: false
+

--- a/plugin/yaml/src/test/resources/probes/valid/hostconfig.yaml
+++ b/plugin/yaml/src/test/resources/probes/valid/hostconfig.yaml
@@ -1,0 +1,17 @@
+service::email_server_host: 'mail.server.org'
+service::email_server_port: 25
+
+# %{::uuu} is not a valid token but '%{:uuu}' is valid
+# see hostconfig-invalid.yml
+service::master_pattern: '%{::uuu}'
+service::cluster_id: 1
+
+service::listpusher_yps_enabled: true
+service::listpusher_yps_enabled: true
+xyz_hosts_int:
+  - 'hosta.somewhere.in.no'
+  - 'hostb.somewhere.in.no'
+
+service::b_enabled: true
+service::a_enabled: false
+


### PR DESCRIPTION
In case of a non-parsable YAML file, the node representing the YAML file will not have any child nodes for YAML documents.