### PR TITLE
Fixed #246 Check maven-surefire-plugin configuration/definition

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -195,6 +195,13 @@
                                     <requireJavaVersion>
                                         <version>1.8</version>
                                     </requireJavaVersion>
+                                    <requireSameVersions>
+                                      <plugins>
+                                        <plugin>org.apache.maven.plugins:maven-surefire-plugin</plugin>
+                                        <plugin>org.apache.maven.plugins:maven-failsafe-plugin</plugin>
+                                        <plugin>org.apache.maven.plugins:maven-surefire-report-plugin</plugin>
+                                      </plugins>
+                                    </requireSameVersions>
                                 </rules>
                             </configuration>
                         </execution>
@@ -252,13 +259,6 @@
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-failsafe-plugin</artifactId>
                     <version>${maven.failsafe.version}</version>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit47</artifactId>
-                            <version>${maven.failsafe.version}</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -269,13 +269,6 @@
                             <include>**/*Test.java</include>
                         </includes>
                     </configuration>
-                    <dependencies>
-                        <dependency>
-                            <groupId>org.apache.maven.surefire</groupId>
-                            <artifactId>surefire-junit47</artifactId>
-                            <version>2.18</version>
-                        </dependency>
-                    </dependencies>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>


### PR DESCRIPTION
Removed provider dependencies, cause this will be done
by maven-surefire/maven-failsafe automatically.
Added maven-enforcer rule to make sure maven-surefire/
maven-failsafe/maven-surefire-report-plugin will have
the same version.