### PR TITLE
Fixed #253 POM cleanup

### DIFF
--- a/plugin/all/pom.xml
+++ b/plugin/all/pom.xml
@@ -6,7 +6,6 @@
         <artifactId>jqassistant.plugin</artifactId>
         <version>1.1.0-SNAPSHOT</version>
     </parent>
-    <groupId>com.buschmais.jqassistant.plugin</groupId>
     <artifactId>jqassistant.plugin.all</artifactId>
 
     <dependencyManagement>

--- a/scm/cli/pom.xml
+++ b/scm/cli/pom.xml
@@ -127,7 +127,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>${org.slf4j_version}</version>
             <scope>runtime</scope>
         </dependency>
         <dependency>

--- a/scm/neo4jserver/pom.xml
+++ b/scm/neo4jserver/pom.xml
@@ -122,7 +122,6 @@
         <dependency>
             <groupId>org.slf4j</groupId>
             <artifactId>slf4j-simple</artifactId>
-            <version>${org.slf4j_version}</version>
             <scope>test</scope>
         </dependency>
     </dependencies>


### PR DESCRIPTION
Remove duplicate groupId in module jqassistant.plugin.all cause it is
inherited from parent.
Remove property usage in scm.cli, scm.neo4jservr, cause their versions
are already defined by dependencyManagement in
com.buschmais.jqassistant::qassistant