### PR TITLE
Fixed #258 POM / PluginManagement Improvements

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -437,11 +437,6 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
-                    <artifactId>maven-install-plugin</artifactId>
-                    <version>2.5.2</version>
-                </plugin>
-                <plugin>
-                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-source-plugin</artifactId>
                     <version>2.4</version>
                     <executions>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.5</version>
+                    <version>2.5.3</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.buschmais.jqassistant</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -354,7 +354,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-assembly-plugin</artifactId>
-                    <version>2.5.3</version>
+                    <version>2.5.5</version>
                     <dependencies>
                         <dependency>
                             <groupId>com.buschmais.jqassistant</groupId>
@@ -413,12 +413,12 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-jar-plugin</artifactId>
-                    <version>2.4</version>
+                    <version>2.6</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-shade-plugin</artifactId>
-                    <version>2.3</version>
+                    <version>2.4.1</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -442,13 +442,29 @@
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-source-plugin</artifactId>
+                    <version>2.4</version>
+                    <executions>
+                      <!-- 
+                        ! here we override the super-pom attach-sources execution id which 
+                        ! calls sources:jar goal. That goals forks the lifecycle, 
+                        ! causing the generate-sources phase to be called twice for the install goal.
+                      -->
+                      <execution>
+                        <id>attach-sources</id>
+                        <phase>DISABLE_FORKED_LIFECYCLE_MSOURCES-13</phase>
+                      </execution>
+                    </executions>
+                  </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-site-plugin</artifactId>
-                    <version>3.3</version>
+                    <version>3.4</version>
                     <dependencies>
                         <dependency>
                             <groupId>org.apache.maven.doxia</groupId>
                             <artifactId>doxia-module-markdown</artifactId>
-                            <version>1.4</version>
+                            <version>1.6</version>
                         </dependency>
                         <dependency>
                             <groupId>org.asciidoctor</groupId>
@@ -459,6 +475,11 @@
                     <configuration>
                         <skipDeploy>true</skipDeploy>
                     </configuration>
+                </plugin>
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-project-info-reports-plugin</artifactId>
+                    <version>2.8</version>
                 </plugin>
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
@@ -475,6 +496,22 @@
                   <artifactId>maven-gpg-plugin</artifactId>
                   <version>1.6</version>
                 </plugin>
+                <!--
+                  ! For the maven plugin area.
+                -->
+                <plugin>
+                    <groupId>org.apache.maven.plugins</groupId>
+                    <artifactId>maven-invoker-plugin</artifactId>
+                    <version>2.0.0</version>
+                </plugin>
+                <!--
+                  ! Other used plugins
+                -->
+                <plugin>
+                    <groupId>com.github.github</groupId>
+                    <artifactId>site-maven-plugin</artifactId>
+                    <version>0.11</version>
+                  </plugin>
             </plugins>
         </pluginManagement>
         <plugins>
@@ -509,7 +546,6 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-source-plugin</artifactId>
-                <version>2.2.1</version>
                 <executions>
                     <execution>
                         <id>attach-sources</id>
@@ -522,7 +558,6 @@
             <plugin>
                 <groupId>com.github.github</groupId>
                 <artifactId>site-maven-plugin</artifactId>
-                <version>0.11</version>
                 <configuration>
                     <message>Creating site for ${project.artifactId}, ${project.version}</message>
                     <path>${project.distributionManagement.site.url}</path>
@@ -546,12 +581,10 @@
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-project-info-reports-plugin</artifactId>
-                <version>2.8</version>
             </plugin>
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-javadoc-plugin</artifactId>
-                <version>2.10.1</version>
                 <reportSets>
                     <reportSet>
                         <reports>

--- a/scm/jqassistant-maven-plugin/pom.xml
+++ b/scm/jqassistant-maven-plugin/pom.xml
@@ -18,7 +18,6 @@
                 <plugins>
                     <plugin>
                         <artifactId>maven-invoker-plugin</artifactId>
-                        <version>1.9</version>
                         <configuration>
                             <cloneProjectsTo>${project.build.directory}/it</cloneProjectsTo>
                             <settingsFile>src/it/settings.xml</settingsFile>
@@ -52,14 +51,6 @@
                                 </goals>
                             </execution>
                         </executions>
-                        <dependencies>
-                            <dependency>
-                                <!-- remove when using maven-invoker-plugin 1.10 -->
-                                <groupId>org.apache.maven.shared</groupId>
-                                <artifactId>maven-invoker</artifactId>
-                                <version>2.2</version>
-                            </dependency>
-                        </dependencies>
                     </plugin>
                 </plugins>
             </build>
@@ -191,7 +182,8 @@
         <dependency>
             <groupId>org.apache.maven.plugin-tools</groupId>
             <artifactId>maven-plugin-annotations</artifactId>
-            <version>3.2</version>
+            <version>3.4</version>
+            <scope>provided</scope>
         </dependency>
         <dependency>
             <groupId>com.googlecode.slf4j-maven-plugin-log</groupId>

--- a/scm/pom.xml
+++ b/scm/pom.xml
@@ -20,7 +20,7 @@
                 <plugin>
                     <groupId>org.apache.maven.plugins</groupId>
                     <artifactId>maven-plugin-plugin</artifactId>
-                    <version>3.2</version>
+                    <version>3.4</version>
                     <configuration>
                         <skipErrorNoDescriptorsFound>true</skipErrorNoDescriptorsFound>
                     </configuration>


### PR DESCRIPTION
- Upgrade maven-plugin-plugin to 3.4
- Upgrade maven-invoker-plugin to 2.0.0 and cleaned up pom accordingly.
- Upgrade maven-source-plugin from 2.2.1 to 2.4 added config to replace
- configuration of the super pom to prevent forks of the life cycle.
- Upgrade doxia-module-markdown from 1.4 to 1.6
- Upgrade maven-shade-plugin from 2.3 to 2.4.1
- Upgrade maven-jar-plugin from 2.4 to 2.6
- Upgrade maven-assembly-plugin from 2.5.3 to 2.5.5
- Correct usage of maven-plugin-annotations (scope=provided)