### PR TITLE
Guard against NPE in TypeCache and ClassVisitor

### DIFF
--- a/plugin/java/src/main/java/com/buschmais/jqassistant/plugin/java/api/scanner/ArtifactScopedTypeResolver.java
+++ b/plugin/java/src/main/java/com/buschmais/jqassistant/plugin/java/api/scanner/ArtifactScopedTypeResolver.java
@@ -73,8 +73,10 @@ public class ArtifactScopedTypeResolver implements TypeResolver {
             if (typeDescriptor == null) {
                 String requiredFileName = "/" + fullQualifiedName.replace(".", "/") + ".class";
                 typeDescriptor = require(requiredFileName, ClassFileDescriptor.class, context);
-                setTypeProperties(typeDescriptor, fullQualifiedName);
-                artifactTypes.put(fullQualifiedName, typeDescriptor);
+                if (typeDescriptor != null) {
+                    setTypeProperties(typeDescriptor, fullQualifiedName);
+                    artifactTypes.put(fullQualifiedName, typeDescriptor);
+                }
             }
             cachedType = getCachedType(fullQualifiedName, typeDescriptor);
         }

--- a/plugin/java/src/main/java/com/buschmais/jqassistant/plugin/java/impl/scanner/visitor/ClassVisitor.java
+++ b/plugin/java/src/main/java/com/buschmais/jqassistant/plugin/java/impl/scanner/visitor/ClassVisitor.java
@@ -117,6 +117,9 @@ public class ClassVisitor extends org.objectweb.asm.ClassVisitor {
 
     @Override
     public RecordComponentVisitor visitRecordComponent(String name, String descriptor, String signature) {
+        if (cachedType == null) {
+            return null;
+        }
         cachedType.getTypeDescriptor()
             .setStatic(true);
         cachedType.getTypeDescriptor()
@@ -126,6 +129,9 @@ public class ClassVisitor extends org.objectweb.asm.ClassVisitor {
 
     @Override
     public FieldVisitor visitField(final int access, final String name, final String desc, final String signature, final Object value) {
+        if (cachedType == null) {
+            return null;
+        }
         final FieldDescriptor fieldDescriptor = visitorHelper.getFieldDescriptor(cachedType, SignatureHelper.getFieldSignature(name, desc));
         fieldDescriptor.setName(name);
         fieldDescriptor.setVolatile(visitorHelper.hasFlag(access, Opcodes.ACC_VOLATILE));
@@ -158,6 +164,9 @@ public class ClassVisitor extends org.objectweb.asm.ClassVisitor {
     @Override
     public org.objectweb.asm.MethodVisitor visitMethod(final int access, final String name, final String desc, final String signature,
         final String[] exceptions) {
+        if (cachedType == null) {
+            return null;
+        }
         String methodSignature = SignatureHelper.getMethodSignature(name, desc);
         MethodDescriptor methodDescriptor = visitorHelper.getMethodDescriptor(cachedType, methodSignature);
         if (isLambda(name, access)) {
@@ -249,6 +258,9 @@ public class ClassVisitor extends org.objectweb.asm.ClassVisitor {
 
     @Override
     public void visitInnerClass(final String name, final String outerName, final String innerName, final int access) {
+        if (cachedType == null) {
+            return;
+        }
         String fullQualifiedName = cachedType.getTypeDescriptor()
             .getFullQualifiedName();
         // innerName always represents the name of the inner class
@@ -268,6 +280,9 @@ public class ClassVisitor extends org.objectweb.asm.ClassVisitor {
 
     @Override
     public void visitOuterClass(final String owner, final String name, final String desc) {
+        if (cachedType == null) {
+            return;
+        }
         String outerTypeName = SignatureHelper.getObjectType(owner);
         TypeCache.CachedType<?> cachedOuterType = visitorHelper.resolveType(outerTypeName, this.cachedType);
         TypeDescriptor innerType = this.cachedType.getTypeDescriptor();
@@ -286,6 +301,9 @@ public class ClassVisitor extends org.objectweb.asm.ClassVisitor {
 
     @Override
     public AnnotationVisitor visitAnnotation(final String desc, final boolean visible) {
+        if (cachedType == null) {
+            return null;
+        }
         return visitorHelper.addAnnotation(cachedType, cachedType.getTypeDescriptor(), SignatureHelper.getType(desc));
     }
 

--- a/plugin/java/src/test/java/com/buschmais/jqassistant/plugin/java/api/scanner/ArtifactScopedTypeResolverTest.java
+++ b/plugin/java/src/test/java/com/buschmais/jqassistant/plugin/java/api/scanner/ArtifactScopedTypeResolverTest.java
@@ -1,0 +1,53 @@
+package com.buschmais.jqassistant.plugin.java.api.scanner;
+
+import java.util.Collections;
+
+import com.buschmais.jqassistant.core.scanner.api.ScannerContext;
+import com.buschmais.jqassistant.plugin.common.api.scanner.FileResolver;
+import com.buschmais.jqassistant.plugin.java.api.model.ClassFileDescriptor;
+import com.buschmais.jqassistant.plugin.java.api.model.JavaArtifactFileDescriptor;
+import com.buschmais.jqassistant.plugin.java.api.model.TypeDescriptor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.*;
+import static org.mockito.Mockito.when;
+
+@ExtendWith(MockitoExtension.class)
+class ArtifactScopedTypeResolverTest {
+
+    @Mock
+    private JavaArtifactFileDescriptor artifact;
+
+    @Mock
+    private ScannerContext scannerContext;
+
+    @Mock
+    private FileResolver fileResolver;
+
+    private ArtifactScopedTypeResolver resolver;
+
+    @BeforeEach
+    void setUp() {
+        when(artifact.getNumberOfDependencies()).thenReturn(0L);
+        when(artifact.getContains()).thenReturn(Collections.emptyList());
+        when(artifact.getRequires()).thenReturn(Collections.emptyList());
+        resolver = new ArtifactScopedTypeResolver(artifact);
+    }
+
+    @Test
+    void resolveReturnsNullWhenRequireFails() {
+        when(scannerContext.peek(FileResolver.class)).thenReturn(fileResolver);
+        when(fileResolver.require(anyString(), anyString(), eq(ClassFileDescriptor.class), eq(scannerContext))).thenReturn(null);
+
+        TypeCache.CachedType<TypeDescriptor> result = resolver.resolve("com.example.NonExistent", scannerContext);
+
+        assertThat(result).isNotNull();
+        assertThat(result.getTypeDescriptor()).isNull();
+    }
+}

--- a/plugin/java/src/test/java/com/buschmais/jqassistant/plugin/java/impl/scanner/visitor/ClassVisitorTest.java
+++ b/plugin/java/src/test/java/com/buschmais/jqassistant/plugin/java/impl/scanner/visitor/ClassVisitorTest.java
@@ -1,0 +1,73 @@
+package com.buschmais.jqassistant.plugin.java.impl.scanner.visitor;
+
+import com.buschmais.jqassistant.plugin.common.api.model.FileDescriptor;
+
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.objectweb.asm.AnnotationVisitor;
+import org.objectweb.asm.FieldVisitor;
+import org.objectweb.asm.MethodVisitor;
+import org.objectweb.asm.RecordComponentVisitor;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Verifies that {@link ClassVisitor} handles null cachedType gracefully,
+ * e.g. when processing module-info.class where cachedType is never initialized.
+ */
+@ExtendWith(MockitoExtension.class)
+class ClassVisitorTest {
+
+    @Mock
+    private FileDescriptor fileDescriptor;
+
+    @Mock
+    private VisitorHelper visitorHelper;
+
+    private ClassVisitor classVisitor;
+
+    @BeforeEach
+    void setUp() {
+        // cachedType remains null (simulates module-info.class scenario)
+        classVisitor = new ClassVisitor(fileDescriptor, visitorHelper);
+    }
+
+    @Test
+    void visitRecordComponentWithNullCachedType() {
+        RecordComponentVisitor result = classVisitor.visitRecordComponent("name", "Ljava/lang/String;", null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void visitFieldWithNullCachedType() {
+        FieldVisitor result = classVisitor.visitField(0, "field", "I", null, null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void visitMethodWithNullCachedType() {
+        MethodVisitor result = classVisitor.visitMethod(0, "method", "()V", null, null);
+        assertThat(result).isNull();
+    }
+
+    @Test
+    void visitInnerClassWithNullCachedType() {
+        classVisitor.visitInnerClass("Inner", "Outer", "Inner", 0);
+        // should not throw NPE
+    }
+
+    @Test
+    void visitOuterClassWithNullCachedType() {
+        classVisitor.visitOuterClass("Outer", "method", "()V");
+        // should not throw NPE
+    }
+
+    @Test
+    void visitAnnotationWithNullCachedType() {
+        AnnotationVisitor result = classVisitor.visitAnnotation("Ljava/lang/Deprecated;", true);
+        assertThat(result).isNull();
+    }
+}


### PR DESCRIPTION
## Summary
- Add null check in `ArtifactScopedTypeResolver.resolve()` when `require()` returns null for unresolvable class files
- Add null guards for `cachedType` in `ClassVisitor` methods that can be called for `module-info.class` where `cachedType` is never initialized
- Added unit tests for both fixes

## Test plan
- [x] New unit test: `ArtifactScopedTypeResolverTest` — verifies `resolve()` handles null from `require()`
- [x] New unit test: `ClassVisitorTest` — 6 tests verifying all guarded methods handle null `cachedType`
- [x] All existing unit tests pass

Fixes #1113

🤖 Generated with [Claude Code](https://claude.com/claude-code)