### PR TITLE
Fix NPE in MavenPomFileScannerPlugin when scan returns null

### DIFF
--- a/plugin/maven/src/main/java/com/buschmais/jqassistant/plugin/maven3/impl/scanner/MavenPomFileScannerPlugin.java
+++ b/plugin/maven/src/main/java/com/buschmais/jqassistant/plugin/maven3/impl/scanner/MavenPomFileScannerPlugin.java
@@ -60,8 +60,13 @@ public class MavenPomFileScannerPlugin extends AbstractXmlFileScannerPlugin<Mave
             scanner.getContext().push(MavenPomDescriptor.class, mavenPomXmlDescriptor);
             try {
                 MavenPomXmlDescriptor result = scanner.scan(model, path, scope);
-                result.setValid(true);
-                return result;
+                if (result != null) {
+                    result.setValid(true);
+                    return result;
+                } else {
+                    mavenPomXmlDescriptor.setValid(false);
+                    return mavenPomXmlDescriptor;
+                }
             } finally {
                 scanner.getContext().pop(MavenPomDescriptor.class);
             }


### PR DESCRIPTION
## Summary

- Add null check for `scanner.scan()` result in `MavenPomFileScannerPlugin.scan()` before calling `setValid()`
- When `scanner.scan()` returns null (e.g. due to an `IOException`), mark the original descriptor as invalid and return it instead of throwing NPE
- Add two unit tests covering the happy path and the null-result scenario

## Test plan

- [x] Existing unit tests pass (5 tests)
- [x] New test: `scanReturnsResultWhenScannerReturnsDescriptor` — verifies happy path
- [x] New test: `scanReturnsInputDescriptorWhenScannerReturnsNull` — verifies null handling
- [x] Checkstyle passes

Fixes #1114

🤖 Generated with [Claude Code](https://claude.com/claude-code)